### PR TITLE
Added classloader to ScriptEngineManager call

### DIFF
--- a/src/main/java/ortus/boxlang/modules/jython/JythonEngine.java
+++ b/src/main/java/ortus/boxlang/modules/jython/JythonEngine.java
@@ -38,7 +38,7 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 
 public class JythonEngine {
 
-	private static final ScriptEngineManager SCRIPT_MANAGER = new ScriptEngineManager();
+	private static final ScriptEngineManager SCRIPT_MANAGER = new ScriptEngineManager(JythonEngine.class.getClassLoader());
 
 	public static IStruct eval( IBoxContext context, String script ) {
 		ScriptEngine	jython		= SCRIPT_MANAGER.getEngineByName( "jython" );


### PR DESCRIPTION

# Description

This fixes an issue where the module throws 

Cannot invoke "javax.script.ScriptEngine.createBindings()" because "jython" is null java.lang.NullPointerException: Cannot invoke "javax.script.ScriptEngine.createBindings()" because "jython" is null
	at bx-jython//ortus.boxlang.modules.jython.JythonEngine.eval(JythonEngine.java:47)
**Please note that all PRs must have tests attached to them**

BUILD SUCCESSFUL in 9s
9 actionable tasks: 6 executed, 3 up-to-date

## Jira/Github Issues

https://github.com/ortus-boxlang/bx-jython/issues/7


## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
